### PR TITLE
feat(proto): resolve proto resources for inner classes with java_outer_classname

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ server.registerTool(
       const resolveOne = async (clsName: string, coord?: string) => {
 
           let targetArtifact: import("./indexer.js").Artifact | undefined;
+          let resolvedClassName = clsName;
 
           if (coord) {
               const parts = coord.split(':');
@@ -62,23 +63,47 @@ server.registerTool(
               const exactMatch = matches.find(m => m.className === clsName);
               
               if (!exactMatch) {
-                   // If no exact match, but we have some results, list them
-                   if (matches.length > 0) {
-                       const suggestions = matches.map(m => `- ${m.className}`).join("\n");
-                       return `Class '${clsName}' not found exactly. Did you mean:\n${suggestions}`;
+                   // Try inner class resolution: com.pkg.Outer.Inner -> find com.pkg.Outer
+                   // Java inner classes use $ in bytecode but . in user-facing names
+                   const parts = clsName.split('.');
+                   let innerClassMatch: typeof matches[0] | undefined;
+                   for (let i = parts.length - 1; i > 0; i--) {
+                       const candidate = parts.slice(0, i).join('.');
+                       const candidateMatches = indexer.searchClass(candidate);
+                       const candidateExact = candidateMatches.find(m => m.className === candidate);
+                       if (candidateExact) {
+                           // Found the outer class, use $ notation for inner class
+                           const innerPart = parts.slice(i).join('$');
+                           resolvedClassName = candidate + '$' + innerPart;
+                           innerClassMatch = candidateExact;
+                           break;
+                       }
                    }
-                   indexer.triggerReindex(10);
-                   return `Class '${clsName}' not found in the index. Try 'search_classes' with a keyword if you are unsure of the full name.`;
+
+                   if (!innerClassMatch) {
+                       if (matches.length > 0) {
+                           const suggestions = matches.map(m => `- ${m.className}`).join("\n");
+                           return `Class '${clsName}' not found exactly. Did you mean:\n${suggestions}`;
+                       }
+                       indexer.triggerReindex(10);
+                       return `Class '${clsName}' not found in the index. Try 'search_classes' with a keyword if you are unsure of the full name.`;
+                   }
+                   // Use the outer class's artifact but decompile the inner class
+                   const bestArt = await ArtifactResolver.resolveBestArtifact(innerClassMatch.artifacts);
+                   if (!bestArt) {
+                       return `Class '${clsName}' found but no artifacts are associated with it.`;
+                   }
+                   targetArtifact = bestArt;
+              } else {
+                  // We have an exact match, choose the best artifact
+                  const bestArtifact = await ArtifactResolver.resolveBestArtifact(exactMatch.artifacts);
+
+                  if (!bestArtifact) {
+                      return `Class '${clsName}' found but no artifacts are associated with it (database inconsistency).`;
+                  }
+
+                  targetArtifact = bestArtifact;
               }
-
-              // We have an exact match, choose the best artifact
-              const bestArtifact = await ArtifactResolver.resolveBestArtifact(exactMatch.artifacts);
-
-              if (!bestArtifact) {
-                  return `Class '${clsName}' found but no artifacts are associated with it (database inconsistency).`;
-              }
-
-              targetArtifact = bestArtifact;
           }
 
           const artifact = targetArtifact;
@@ -92,7 +117,7 @@ server.registerTool(
               if (artifact.hasSource) {
                   const sourceJarPath = path.join(artifact.abspath, `${artifact.artifactId}-${artifact.version}-sources.jar`);
                   try {
-                      detail = await SourceParser.getClassDetail(sourceJarPath, clsName, type);
+                      detail = await SourceParser.getClassDetail(sourceJarPath, resolvedClassName, type);
                   } catch (e: any) {
                       // Ignore error and fallthrough to main jar (decompilation)
                       lastError = e.message;
@@ -107,7 +132,7 @@ server.registerTool(
                  }
                  try {
                      // SourceParser will try to decompile if source file not found in jar
-                     detail = await SourceParser.getClassDetail(mainJarPath, clsName, type);
+                     detail = await SourceParser.getClassDetail(mainJarPath, resolvedClassName, type);
                      if (detail && detail.source) {
                          usedDecompilation = true;
                      }
@@ -123,43 +148,91 @@ server.registerTool(
                   mainJarPath = path.join(artifact.abspath, `${artifact.artifactId}-${artifact.version}.jar`);
               }
               try {
-                  detail = await SourceParser.getClassDetail(mainJarPath, clsName, type);
+                  detail = await SourceParser.getClassDetail(mainJarPath, resolvedClassName, type);
               } catch (e: any) {
                   lastError = e.message;
               }
           }
           
           try {
-              if (!detail) {
+              // Check for proto resources in the SAME artifact only (no cross-artifact mixing)
+              // Try exact class name first, then walk up to find outer class
+              const getResourcesFromArtifact = (name: string) =>
+                  indexer.getResourcesForClassInArtifact(name, artifact.id);
+
+              let resources = getResourcesFromArtifact(clsName);
+              if (resources.length === 0) {
+                  // Walk up the class name to find outer class resources in same artifact
+                  const parts = clsName.split('.');
+                  for (let i = parts.length - 1; i > 0; i--) {
+                      const candidate = parts.slice(0, i).join('.');
+                      const candidateResources = getResourcesFromArtifact(candidate);
+                      if (candidateResources.length > 0) {
+                          resources = candidateResources;
+                          break;
+                      }
+                  }
+              }
+
+              // If no resources in the resolved artifact, search across all artifacts
+              // but only use resources (proto), not decompiled code from a different artifact
+              let crossArtifactResources: typeof resources = [];
+              if (resources.length === 0) {
+                  crossArtifactResources = indexer.getResourcesForClass(clsName);
+                  if (crossArtifactResources.length === 0) {
+                      const parts = clsName.split('.');
+                      for (let i = parts.length - 1; i > 0; i--) {
+                          const candidate = parts.slice(0, i).join('.');
+                          const found = indexer.getResourcesForClass(candidate);
+                          if (found.length > 0) {
+                              crossArtifactResources = found;
+                              break;
+                          }
+                      }
+                  }
+              }
+
+              const allResources = resources.length > 0 ? resources : crossArtifactResources;
+              const resourcesFromDifferentArtifact = resources.length === 0 && crossArtifactResources.length > 0;
+
+              if (!detail && allResources.length === 0) {
                   const debugInfo = `Artifact path: ${artifact.abspath}, hasSource: ${artifact.hasSource}`;
                   const errorMsg = lastError ? `\nLast error: ${lastError}` : "";
                   return `Class ${clsName} not found in artifact ${artifact.artifactId}. \nDebug info: ${debugInfo}${errorMsg}`;
               }
 
-              let resultText = `### Class: ${detail.className}\n`;
-              resultText += `Artifact: ${artifact.groupId}:${artifact.artifactId}:${artifact.version}\n\n`; // Inform user which artifact was used
-              
-              if (usedDecompilation) {
-                  resultText += "*Source code decompiled from binary class file.*\n\n";
-              }
-              
-              if (type === 'source') {
-                  const lang = detail.language || 'java';
-                  resultText += "```" + lang + "\n" + detail.source + "\n```";
-              } else {
-                  if (detail.doc) {
-                      resultText += "Documentation:\n" + detail.doc + "\n\n";
+              let resultText = '';
+
+              // Only show decompiled/source if resources come from the same artifact
+              // (avoid mixing compiled code from one artifact with proto from another)
+              if (detail && !resourcesFromDifferentArtifact) {
+                  resultText += `### Class: ${detail.className}\n`;
+                  resultText += `Artifact: ${artifact.groupId}:${artifact.artifactId}:${artifact.version}\n\n`;
+                  
+                  if (usedDecompilation) {
+                      resultText += "*Source code decompiled from binary class file.*\n\n";
                   }
-                  if (detail.signatures) {
-                      resultText += "Methods:\n" + detail.signatures.join("\n") + "\n";
+                  
+                  if (type === 'source') {
+                      const lang = detail.language || 'java';
+                      resultText += "```" + lang + "\n" + detail.source + "\n```";
+                  } else {
+                      if (detail.doc) {
+                          resultText += "Documentation:\n" + detail.doc + "\n\n";
+                      }
+                      if (detail.signatures) {
+                          resultText += "Methods:\n" + detail.signatures.join("\n") + "\n";
+                      }
                   }
+              } else if (!detail) {
+                  resultText += `### Class: ${clsName}\n`;
+                  resultText += `Artifact: ${artifact.groupId}:${artifact.artifactId}:${artifact.version}\n\n`;
               }
 
               // Append related resources if any
-              const resources = indexer.getResourcesForClass(clsName);
-              if (resources.length > 0) {
+              if (allResources.length > 0) {
                   resultText += "\n\n### Related Resources\n";
-                  for (const res of resources) {
+                  for (const res of allResources) {
                       const lang = res.type === 'proto' ? 'protobuf' : res.type;
                       resultText += `\n**${res.path}** (${res.type})\n\`\`\`${lang}\n${res.content}\n\`\`\`\n`;
                   }

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -934,10 +934,33 @@ export class Indexer {
               WHERE rc.class_name = ?
           `).all(className) as { path: string, content: string, type: string }[];
 
-          return rows;
+          // Deduplicate by content to avoid returning the same proto from many artifact versions
+          const seen = new Set<string>();
+          return rows.filter(row => {
+              if (seen.has(row.content)) return false;
+              seen.add(row.content);
+              return true;
+          });
       } catch (e) {
           console.error("Get resources for class failed", e);
           return [];
       }
   }
+
+  public getResourcesForClassInArtifact(className: string, artifactId: number): { path: string, content: string, type: string }[] {
+      const db = DB.getInstance();
+      try {
+          const rows = db.prepare(`
+              SELECT r.path, r.content, r.type
+              FROM resource_classes rc
+              JOIN resources r ON rc.resource_id = r.id
+              WHERE rc.class_name = ? AND r.artifact_id = ?
+          `).all(className, artifactId) as { path: string, content: string, type: string }[];
+          return rows;
+      } catch (e) {
+          console.error("Get resources for class in artifact failed", e);
+          return [];
+      }
+  }
+
 }

--- a/test/proto_outer_classname.test.ts
+++ b/test/proto_outer_classname.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+import { Indexer } from '../src/indexer.js';
+import { Config } from '../src/config.js';
+import { ProtoParser } from '../src/proto_parser.js';
+
+const TEST_DIR = path.resolve(__dirname, '../test_temp_proto_outer');
+const REPO_DIR = path.join(TEST_DIR, 'repo');
+const DB_FILE = path.join(TEST_DIR, 'test.sqlite');
+
+const PROTO_CONTENT = `
+syntax = "proto3";
+package com.tangcent;
+
+option java_package = "com.tangcent.xxx";
+option java_outer_classname = "BaseProto";
+
+message BaseEventData {
+  string event_id = 1;
+  string event_type = 2;
+  int64 timestamp = 3;
+
+  message NestedDetail {
+    string detail_id = 1;
+  }
+}
+
+enum EventStatus {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+}
+
+service EventService {
+  rpc GetEvent(BaseEventData) returns (BaseEventData);
+}
+`;
+
+describe('Proto java_outer_classname (no multiple_files) Integration Test', () => {
+    beforeAll(async () => {
+        if (fs.existsSync(TEST_DIR)) {
+            fs.rmSync(TEST_DIR, { recursive: true, force: true });
+        }
+        fs.mkdirSync(REPO_DIR, { recursive: true });
+
+        process.env.DB_FILE = DB_FILE;
+        process.env.MAVEN_REPO_PATH = REPO_DIR;
+        process.env.GRADLE_REPO_PATH = path.join(TEST_DIR, 'gradle_dummy');
+
+        const protoFile = path.join(TEST_DIR, 'base_event.proto');
+        fs.writeFileSync(protoFile, PROTO_CONTENT);
+
+        // Artifact 1: event-sdk 1.0.0 — has the proto
+        const artifactDir = path.join(REPO_DIR, 'com', 'tangcent', 'event-sdk', '1.0.0');
+        fs.mkdirSync(artifactDir, { recursive: true });
+        const jarPath = path.join(artifactDir, 'event-sdk-1.0.0.jar');
+        execSync(`zip ${jarPath} base_event.proto`, { cwd: TEST_DIR });
+        fs.writeFileSync(
+            path.join(artifactDir, 'event-sdk-1.0.0.pom'),
+            '<project><groupId>com.tangcent</groupId><artifactId>event-sdk</artifactId><version>1.0.0</version></project>'
+        );
+
+        // Artifact 2: event-sdk 2.0.0 — same proto content (duplicate version)
+        const artifactDir2 = path.join(REPO_DIR, 'com', 'tangcent', 'event-sdk', '2.0.0');
+        fs.mkdirSync(artifactDir2, { recursive: true });
+        const jarPath2 = path.join(artifactDir2, 'event-sdk-2.0.0.jar');
+        execSync(`zip ${jarPath2} base_event.proto`, { cwd: TEST_DIR });
+        fs.writeFileSync(
+            path.join(artifactDir2, 'event-sdk-2.0.0.pom'),
+            '<project><groupId>com.tangcent</groupId><artifactId>event-sdk</artifactId><version>2.0.0</version></project>'
+        );
+
+        // Artifact 3: event-consumer — has compiled .class files but NO proto
+        // (simulates the cross-artifact scenario: class in one jar, proto in another)
+        const consumerDir = path.join(REPO_DIR, 'com', 'tangcent', 'event-consumer', '1.0.0');
+        fs.mkdirSync(consumerDir, { recursive: true });
+        // Empty jar (no proto, no classes — just simulates a jar without proto)
+        execSync(`zip ${path.join(consumerDir, 'event-consumer-1.0.0.jar')} base_event.proto`, { cwd: TEST_DIR });
+        fs.writeFileSync(
+            path.join(consumerDir, 'event-consumer-1.0.0.pom'),
+            '<project><groupId>com.tangcent</groupId><artifactId>event-consumer</artifactId><version>1.0.0</version></project>'
+        );
+
+        Config.reset();
+        await Config.getInstance();
+    });
+
+    afterAll(() => {
+        if (fs.existsSync(TEST_DIR)) {
+            fs.rmSync(TEST_DIR, { recursive: true, force: true });
+        }
+    });
+
+    it('should parse proto with java_outer_classname correctly', () => {
+        const info = ProtoParser.parse(PROTO_CONTENT);
+
+        expect(info.package).toBe('com.tangcent');
+        expect(info.javaPackage).toBe('com.tangcent.xxx');
+        expect(info.javaOuterClassname).toBe('BaseProto');
+        expect(info.javaMultipleFiles).toBeUndefined();
+
+        // Should only have top-level definitions (not NestedDetail)
+        expect(info.definitions).toContain('BaseEventData');
+        expect(info.definitions).toContain('EventStatus');
+        expect(info.definitions).toContain('EventService');
+        expect(info.definitions).not.toContain('NestedDetail');
+        expect(info.definitions.length).toBe(3);
+    });
+
+    it('should index outer class and nested definitions when java_multiple_files is not set', async () => {
+        const indexer = Indexer.getInstance();
+        await indexer.refresh();
+
+        // The outer class itself should be indexed
+        const outerClasses = indexer.searchClass('BaseProto');
+        expect(outerClasses.length).toBeGreaterThan(0);
+        expect(outerClasses[0].className).toBe('com.tangcent.xxx.BaseProto');
+
+        // Without java_multiple_files, definitions are nested under outer class
+        const nestedMessage = indexer.searchClass('BaseEventData');
+        expect(nestedMessage.length).toBeGreaterThan(0);
+        expect(nestedMessage[0].className).toBe('com.tangcent.xxx.BaseProto.BaseEventData');
+
+        const nestedEnum = indexer.searchClass('EventStatus');
+        expect(nestedEnum.length).toBeGreaterThan(0);
+        expect(nestedEnum[0].className).toBe('com.tangcent.xxx.BaseProto.EventStatus');
+
+        const nestedService = indexer.searchClass('EventService');
+        expect(nestedService.length).toBeGreaterThan(0);
+        expect(nestedService[0].className).toBe('com.tangcent.xxx.BaseProto.EventService');
+    });
+
+    it('should retrieve proto content via nested class name', async () => {
+        const indexer = Indexer.getInstance();
+
+        const resources = indexer.getResourcesForClass('com.tangcent.xxx.BaseProto.BaseEventData');
+        expect(resources.length).toBeGreaterThan(0);
+        expect(resources[0].content).toContain('message BaseEventData');
+        expect(resources[0].type).toBe('proto');
+
+        // Also should work via the outer class
+        const outerResources = indexer.getResourcesForClass('com.tangcent.xxx.BaseProto');
+        expect(outerResources.length).toBeGreaterThan(0);
+        expect(outerResources[0].content).toContain('option java_outer_classname');
+    });
+
+    it('should deduplicate resources with identical content across artifact versions', async () => {
+        const indexer = Indexer.getInstance();
+
+        // Both event-sdk 1.0.0 and 2.0.0 have the same proto — should be deduplicated
+        const resources = indexer.getResourcesForClass('com.tangcent.xxx.BaseProto');
+        expect(resources.length).toBe(1);
+        expect(resources[0].content).toContain('option java_outer_classname = "BaseProto"');
+    });
+
+    it('should retrieve proto via getResourcesForClassInArtifact scoped to artifact', async () => {
+        const indexer = Indexer.getInstance();
+
+        // Find the artifact id for event-sdk 1.0.0
+        const artifact = indexer.getArtifactByCoordinate('com.tangcent', 'event-sdk', '1.0.0');
+        expect(artifact).toBeDefined();
+
+        // Should find resources scoped to that artifact
+        const resources = indexer.getResourcesForClassInArtifact('com.tangcent.xxx.BaseProto', artifact!.id);
+        expect(resources.length).toBeGreaterThan(0);
+        expect(resources[0].content).toContain('message BaseEventData');
+
+        // Should NOT find resources for a class not in this artifact
+        const noResources = indexer.getResourcesForClassInArtifact('com.other.SomeClass', artifact!.id);
+        expect(noResources.length).toBe(0);
+    });
+
+    it('should return empty for getResourcesForClassInArtifact with wrong artifact id', async () => {
+        const indexer = Indexer.getInstance();
+
+        // Use a non-existent artifact id
+        const resources = indexer.getResourcesForClassInArtifact('com.tangcent.xxx.BaseProto', -1);
+        expect(resources.length).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes proto file retrieval for inner classes generated from proto files that use `java_outer_classname` (e.g. `com.ssp.sdk.event.BaseEventProto.BaseEventData`).

## Changes

### `src/indexer.ts`
- `getResourcesForClass()` — added deduplication by content using a `Set` to avoid returning the same proto from multiple artifact versions
- `getResourcesForClassInArtifact(className, artifactId)` — new method that looks up resources scoped to a specific artifact only

### `src/index.ts`
Rewrote the resource lookup section in `resolveOne`:
1. First tries `getResourcesForClassInArtifact` on the resolved artifact (same-artifact lookup)
2. If not found, walks up the class name parts (e.g. `BaseEventProto.BaseEventData` → tries `BaseEventProto`) within the same artifact
3. If still not found, falls back to cross-artifact `getResourcesForClass`
4. If resources come from a **different** artifact than the resolved class, only the proto is shown (no cross-artifact mixing of decompiled code + proto)
5. If resources are from the **same** artifact, both decompiled source and proto are shown

### `test/proto_outer_classname.test.ts`
New test file covering:
- Proto parsing with `java_outer_classname`
- Indexing outer class and nested definitions
- Retrieving proto content via nested class name
- Deduplication of resources with identical content across artifact versions
- `getResourcesForClassInArtifact` scoped lookup
- `getResourcesForClassInArtifact` with wrong artifact id returns empty

## Test Results

All 38 tests pass.