### PR TITLE
fix: add graceful error handling for better-sqlite3 native module failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,19 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: ['22']
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Node.js
+    - name: Set up Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: ${{ matrix.node-version }}
         cache: 'npm'
 
     - name: Set up JDK 11

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -151,4 +151,18 @@ export class DB {
   public transaction<T>(fn: () => T): T {
     return this.db.transaction(fn)();
   }
+
+  public close() {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+    }
+  }
+
+  public static reset() {
+    if (DB.instance) {
+      DB.instance.close();
+      DB.instance = undefined as any;
+    }
+  }
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,22 +1,34 @@
-import Database from 'better-sqlite3';
+import { createRequire } from 'node:module';
 import path from 'path';
 import os from 'os';
 import fs from 'fs';
 
+const require = createRequire(import.meta.url);
+
+let Database: any = null;
+let dbLoadError: string | null = null;
+
+try {
+  Database = require('better-sqlite3');
+} catch (e: any) {
+  dbLoadError = e?.message || String(e);
+}
+
 export class DB {
   private static instance: DB;
-  private db: Database.Database;
+  private db: any;
 
   private constructor() {
-    // Check environment variable for DB path (useful for testing)
+    if (!Database) {
+      throw new Error(dbLoadError || 'better-sqlite3 failed to load');
+    }
+
     if (process.env.DB_FILE) {
       this.db = new Database(process.env.DB_FILE);
     } else {
-      // Use home directory for the database file
       const homeDir = os.homedir();
       const configDir = path.join(homeDir, '.maven-indexer-mcp');
       
-      // Ensure the directory exists
       if (!fs.existsSync(configDir)) {
         fs.mkdirSync(configDir, { recursive: true });
       }
@@ -25,6 +37,28 @@ export class DB {
       this.db = new Database(dbPath);
     }
     this.initSchema();
+  }
+
+  public static isAvailable(): boolean {
+    return Database !== null;
+  }
+
+  public static getLoadError(): string | null {
+    return dbLoadError;
+  }
+
+  public static checkHealth(): string | null {
+    if (!Database) {
+      return dbLoadError || 'better-sqlite3 failed to load';
+    }
+    try {
+      const testDb = new Database(':memory:');
+      testDb.exec('CREATE VIRTUAL TABLE IF NOT EXISTS _health_fts USING fts5(x, tokenize="trigram")');
+      testDb.close();
+    } catch (e: any) {
+      return e?.message || String(e);
+    }
+    return null;
   }
 
   public static getInstance(): DB {
@@ -36,10 +70,10 @@ export class DB {
 
   private initSchema() {
     // Register REGEXP function
-    this.db.function('regexp', { deterministic: true }, (regex, text) => {
+    this.db.function('regexp', { deterministic: true }, (regex: string, text: string) => {
         if (!regex || !text) return 0;
         try {
-            return new RegExp(regex as string).test(text as string) ? 1 : 0;
+            return new RegExp(regex).test(text) ? 1 : 0;
         } catch (e) {
             return 0;
         }
@@ -106,11 +140,11 @@ export class DB {
     }
   }
 
-  public getDb(): Database.Database {
+  public getDb() {
     return this.db;
   }
 
-  public prepare(sql: string): Database.Statement {
+  public prepare(sql: string) {
     return this.db.prepare(sql);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,41 @@ import { z } from "zod";
 import { Indexer, Artifact } from "./indexer.js";
 import { SourceParser } from "./source_parser.js";
 import { ArtifactResolver } from "./artifact_resolver.js";
+import { DB } from "./db/index.js";
+
+const healthError = DB.checkHealth();
+if (healthError) {
+  console.error(`
+================================================================================
+ERROR: Failed to initialize the database engine (better-sqlite3).
+
+This is most likely because the prebuilt binary is not available for your
+platform/Node.js version and the native compilation also failed.
+
+The original error was:
+  ${healthError}
+
+To fix this on Windows:
+  1. Install Visual Studio Build Tools with the "Desktop development with C++"
+     workload from https://visualstudio.microsoft.com/visual-cpp-build-tools/
+  2. Or run the following as Administrator:
+       npm install -g windows-build-tools
+  3. Then retry: npx -y maven-indexer-mcp
+
+To fix this on Linux/macOS:
+  1. Ensure build tools are installed (gcc, g++, make, python3)
+  2. On Debian/Ubuntu: sudo apt-get install build-essential python3
+  3. Then retry: npx -y maven-indexer-mcp
+
+For more information, see:
+  https://github.com/WiseLibs/better-sqlite3/blob/master/docs/compilation.md
+
+If you believe this is a bug, please report it at:
+  https://github.com/tangcent/maven-indexer-mcp/issues
+================================================================================
+`);
+  process.exit(1);
+}
 
 const server = new McpServer(
   {

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -67,11 +67,20 @@ describe('MCP Server Batch Queries', () => {
         createTestArtifact('batch-lib-2', 'BatchClass2');
     });
 
-    afterAll(() => {
-        if (server) server.kill();
+    afterAll(async () => {
+        if (server) {
+            server.kill();
+            await new Promise<void>(resolve => {
+                if (server.killed) { resolve(); return; }
+                server.on('exit', () => resolve());
+                setTimeout(() => resolve(), 5000);
+            });
+        }
         DB.reset();
         if (fs.existsSync(TEST_REPO_DIR)) fs.rmSync(TEST_REPO_DIR, { recursive: true, force: true });
-        if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
+        if (fs.existsSync(DB_FILE)) {
+            try { fs.unlinkSync(DB_FILE); } catch { }
+        }
     });
 
     function sendRequest(method: string, params: any): Promise<any> {

--- a/test/batch.test.ts
+++ b/test/batch.test.ts
@@ -3,6 +3,7 @@ import { spawn, ChildProcess } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { execSync } from 'child_process';
+import { DB } from '../src/db/index';
 
 const TEST_REPO_DIR = path.resolve('test-repo-batch');
 const DB_FILE = 'maven-index-batch.sqlite';
@@ -68,6 +69,7 @@ describe('MCP Server Batch Queries', () => {
 
     afterAll(() => {
         if (server) server.kill();
+        DB.reset();
         if (fs.existsSync(TEST_REPO_DIR)) fs.rmSync(TEST_REPO_DIR, { recursive: true, force: true });
         if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
     });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -3,6 +3,7 @@ import { spawn, ChildProcess } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 import { execSync } from 'child_process';
+import { DB } from '../src/db/index';
 
 const TEST_REPO_DIR = path.resolve('test-repo-e2e');
 const DB_FILE = 'maven-index-e2e.sqlite';
@@ -82,7 +83,7 @@ describe('MCP Server E2E', () => {
 
     afterAll(() => {
         if (server) server.kill();
-        // Cleanup
+        DB.reset();
         if (fs.existsSync(TEST_REPO_DIR)) fs.rmSync(TEST_REPO_DIR, { recursive: true, force: true });
         if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
     });

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -81,11 +81,20 @@ describe('MCP Server E2E', () => {
         createTestArtifact();
     });
 
-    afterAll(() => {
-        if (server) server.kill();
+    afterAll(async () => {
+        if (server) {
+            server.kill();
+            await new Promise<void>(resolve => {
+                if (server.killed) { resolve(); return; }
+                server.on('exit', () => resolve());
+                setTimeout(() => resolve(), 5000);
+            });
+        }
         DB.reset();
         if (fs.existsSync(TEST_REPO_DIR)) fs.rmSync(TEST_REPO_DIR, { recursive: true, force: true });
-        if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
+        if (fs.existsSync(DB_FILE)) {
+            try { fs.unlinkSync(DB_FILE); } catch { }
+        }
     });
 
     function sendRequest(method: string, params: any): Promise<any> {

--- a/test/filtering.test.ts
+++ b/test/filtering.test.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import {execSync} from 'child_process';
 import {Indexer} from '../src/indexer';
 import {Config} from '../src/config';
-import Database from 'better-sqlite3';
+import {DB} from '../src/db/index';
 
 const TEST_REPO_DIR = path.resolve('test-repo-filtering');
 const TEST_GRADLE_DIR = path.resolve('test-gradle-repo-filtering');
@@ -102,12 +102,11 @@ describe('Maven Indexer Filtering', () => {
     });
 
     afterAll(() => {
-        // Cleanup
+        DB.reset();
         if (fs.existsSync(TEST_REPO_DIR)) fs.rmSync(TEST_REPO_DIR, {recursive: true, force: true});
         if (fs.existsSync(TEST_GRADLE_DIR)) fs.rmSync(TEST_GRADLE_DIR, {recursive: true, force: true});
         if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
 
-        // Reset env
         delete process.env.INCLUDED_PACKAGES;
         Config.reset();
     });

--- a/test/gradle.test.ts
+++ b/test/gradle.test.ts
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import { Indexer } from '../src/indexer';
 import { Config } from '../src/config';
+import { DB } from '../src/db/index';
 
 const TEST_GRADLE_REPO = path.resolve('test-repo-gradle');
 const DB_FILE = 'maven-index-gradle.sqlite';
@@ -73,6 +74,8 @@ describe('Gradle Indexer Integration', () => {
     });
 
     afterAll(() => {
+        DB.reset();
+        Config.reset();
         if (fs.existsSync(TEST_GRADLE_REPO)) fs.rmSync(TEST_GRADLE_REPO, { recursive: true, force: true });
         if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
         delete process.env.DB_FILE;

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import { execSync } from 'child_process';
 import { Indexer } from '../src/indexer';
 import { Config } from '../src/config';
-import Database from 'better-sqlite3';
+import { DB } from '../src/db/index';
 
 const TEST_REPO_DIR = path.resolve('test-repo-integration');
 const DB_FILE = 'maven-index.sqlite';
@@ -90,7 +90,8 @@ describe('Maven Indexer Integration', () => {
     });
 
     afterAll(() => {
-        // Cleanup
+        DB.reset();
+        Config.reset();
         if (fs.existsSync(TEST_REPO_DIR)) fs.rmSync(TEST_REPO_DIR, { recursive: true, force: true });
         if (fs.existsSync(DB_FILE)) fs.unlinkSync(DB_FILE);
         delete process.env.DB_FILE;
@@ -100,11 +101,9 @@ describe('Maven Indexer Integration', () => {
         const indexer = Indexer.getInstance();
         await indexer.index();
 
-        // Check DB
-        const db = new Database(DB_FILE);
+        const db = DB.getInstance().getDb();
         const count = db.prepare('SELECT count(*) as c FROM artifacts').get() as {c: number};
         expect(count.c).toBe(2);
-        db.close();
     });
 
     it('should find the class by name', async () => {
@@ -180,12 +179,10 @@ class KotlinUtils {
         `;
         fs.writeFileSync(path.join(ktPkgDir, 'KotlinUtils.kt'), ktContent);
         
-        // Create zip
-        // cd ktSrcDir && zip -r ktSourceJar .
         try {
-             execSync(`cd "${ktSrcDir}" && zip -r "${ktSourceJar}" .`);
+             execSync(`jar -cf "${ktSourceJar}" -C "${ktSrcDir}" .`);
         } catch (e) {
-            console.warn("zip command failed, skipping kotlin test");
+            console.warn("jar command failed, skipping kotlin test");
             return;
         }
         

--- a/test/proto_integration.test.ts
+++ b/test/proto_integration.test.ts
@@ -45,10 +45,8 @@ message TestMessage {
 
         // Create JAR with proto file
         const jarPath = path.join(artifactDir, 'my-proto-1.0.0.jar');
-        // cd to TEST_DIR to zip relative path 'test.proto'
-        execSync(`zip ${jarPath} test.proto`, { cwd: TEST_DIR });
+        execSync(`jar -cf ${jarPath} -C ${TEST_DIR} test.proto`);
 
-        // Create POM
         const pomPath = path.join(artifactDir, 'my-proto-1.0.0.pom');
         fs.writeFileSync(pomPath, '<project><groupId>com.example</groupId><artifactId>my-proto</artifactId><version>1.0.0</version></project>');
 
@@ -58,7 +56,8 @@ message TestMessage {
     });
 
     afterAll(() => {
-        // Cleanup
+        DB.reset();
+        Config.reset();
         if (fs.existsSync(TEST_DIR)) {
             fs.rmSync(TEST_DIR, { recursive: true, force: true });
         }

--- a/test/proto_multiple_files.test.ts
+++ b/test/proto_multiple_files.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { execSync } from 'child_process';
 import { Indexer } from '../src/indexer.js';
 import { Config } from '../src/config.js';
+import { DB } from '../src/db/index.js';
 
 const TEST_DIR = path.resolve(__dirname, '../test_temp_proto_multi');
 const REPO_DIR = path.join(TEST_DIR, 'repo');
@@ -49,9 +50,8 @@ enum MultiEnum {
 
         // Create JAR
         const jarPath = path.join(artifactDir, 'multi-proto-1.0.0.jar');
-        execSync(`zip ${jarPath} multi.proto`, { cwd: TEST_DIR });
+        execSync(`jar -cf ${jarPath} -C ${TEST_DIR} multi.proto`);
 
-        // Create POM
         const pomPath = path.join(artifactDir, 'multi-proto-1.0.0.pom');
         fs.writeFileSync(pomPath, '<project><groupId>com.example</groupId><artifactId>multi-proto</artifactId><version>1.0.0</version></project>');
 
@@ -61,6 +61,8 @@ enum MultiEnum {
     });
 
     afterAll(() => {
+        DB.reset();
+        Config.reset();
         if (fs.existsSync(TEST_DIR)) {
             fs.rmSync(TEST_DIR, { recursive: true, force: true });
         }

--- a/test/proto_outer_classname.test.ts
+++ b/test/proto_outer_classname.test.ts
@@ -5,6 +5,7 @@ import { execSync } from 'child_process';
 import { Indexer } from '../src/indexer.js';
 import { Config } from '../src/config.js';
 import { ProtoParser } from '../src/proto_parser.js';
+import { DB } from '../src/db/index.js';
 
 const TEST_DIR = path.resolve(__dirname, '../test_temp_proto_outer');
 const REPO_DIR = path.join(TEST_DIR, 'repo');
@@ -56,7 +57,7 @@ describe('Proto java_outer_classname (no multiple_files) Integration Test', () =
         const artifactDir = path.join(REPO_DIR, 'com', 'tangcent', 'event-sdk', '1.0.0');
         fs.mkdirSync(artifactDir, { recursive: true });
         const jarPath = path.join(artifactDir, 'event-sdk-1.0.0.jar');
-        execSync(`zip ${jarPath} base_event.proto`, { cwd: TEST_DIR });
+        execSync(`jar -cf ${jarPath} -C ${TEST_DIR} base_event.proto`);
         fs.writeFileSync(
             path.join(artifactDir, 'event-sdk-1.0.0.pom'),
             '<project><groupId>com.tangcent</groupId><artifactId>event-sdk</artifactId><version>1.0.0</version></project>'
@@ -66,7 +67,7 @@ describe('Proto java_outer_classname (no multiple_files) Integration Test', () =
         const artifactDir2 = path.join(REPO_DIR, 'com', 'tangcent', 'event-sdk', '2.0.0');
         fs.mkdirSync(artifactDir2, { recursive: true });
         const jarPath2 = path.join(artifactDir2, 'event-sdk-2.0.0.jar');
-        execSync(`zip ${jarPath2} base_event.proto`, { cwd: TEST_DIR });
+        execSync(`jar -cf ${jarPath2} -C ${TEST_DIR} base_event.proto`);
         fs.writeFileSync(
             path.join(artifactDir2, 'event-sdk-2.0.0.pom'),
             '<project><groupId>com.tangcent</groupId><artifactId>event-sdk</artifactId><version>2.0.0</version></project>'
@@ -77,7 +78,7 @@ describe('Proto java_outer_classname (no multiple_files) Integration Test', () =
         const consumerDir = path.join(REPO_DIR, 'com', 'tangcent', 'event-consumer', '1.0.0');
         fs.mkdirSync(consumerDir, { recursive: true });
         // Empty jar (no proto, no classes — just simulates a jar without proto)
-        execSync(`zip ${path.join(consumerDir, 'event-consumer-1.0.0.jar')} base_event.proto`, { cwd: TEST_DIR });
+        execSync(`jar -cf ${path.join(consumerDir, 'event-consumer-1.0.0.jar')} -C ${TEST_DIR} base_event.proto`);
         fs.writeFileSync(
             path.join(consumerDir, 'event-consumer-1.0.0.pom'),
             '<project><groupId>com.tangcent</groupId><artifactId>event-consumer</artifactId><version>1.0.0</version></project>'
@@ -88,6 +89,8 @@ describe('Proto java_outer_classname (no multiple_files) Integration Test', () =
     });
 
     afterAll(() => {
+        DB.reset();
+        Config.reset();
         if (fs.existsSync(TEST_DIR)) {
             fs.rmSync(TEST_DIR, { recursive: true, force: true });
         }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    hookTimeout: 60_000,
+    testTimeout: 60_000,
+  },
+});


### PR DESCRIPTION
Fixes #6

When the native module better-sqlite3 fails to load, the server now shows a clear, actionable error message instead of silently exiting.

- Replace static import with try-catch via createRequire
- Add DB.checkHealth() for deep health check including FTS5
- Show detailed error message with platform-specific fix instructions
- Update CI to test across ubuntu/macos/windows with Node 22